### PR TITLE
fix(core): 今日/本月判定固定北京时间对齐平台，UI 提示当日统计延迟

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [`windows/README.md`](windows/README.md) for details.
 
 - All data comes from DeepSeek's own platform endpoints (`get_user_summary`, `usage/amount`, `usage/cost`) using **your own login token** — nothing is sent anywhere else
 - The token is stored only in `~/Library/Preferences/com.deepseek.meter.plist` on your machine; use **Sign out** in the popover to remove it
-- Token usage data may lag the dashboard by a few minutes
+- Usage/cost statistics are **not real-time**: same-day figures may lag for hours or until the next day (the balance itself is deducted in real time)
 
 ## 🛠 Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,7 +89,7 @@ pwsh Scripts/publish-windows.ps1    # 生成 windows/publish/DeepSeekMeter-win-x
 
 - 所有数据均来自 DeepSeek 官方平台接口（`get_user_summary` / `usage/amount` / `usage/cost`），使用**你自己的登录态**获取，不会发送到任何第三方
 - Token 只保存在本机 `~/Library/Preferences/com.deepseek.meter.plist`；悬浮窗「退出登录」可随时清除
-- Token 用量数据与控制台可能有数分钟延迟
+- 用量/费用统计**非实时**：当日数据可能延迟数小时甚至次日才更新（余额为实时扣减）
 
 ## 🛠 开发
 

--- a/Scripts/selftest/main.swift
+++ b/Scripts/selftest/main.swift
@@ -23,6 +23,28 @@ check(currencySymbol("HKD") == "HK$", "HKD -> HK$")
 check(currencySymbol("GBP") == "£", "GBP -> £")
 check(currencySymbol("XXX") == "XXX", "未知币种原样返回")
 
+// 1.5 平台时区对齐：北京时间（UTC+8）计日，与 usage/cost、usage/amount 的 days 口径一致
+var utcComps = DateComponents()
+utcComps.calendar = Calendar(identifier: .gregorian)
+utcComps.timeZone = TimeZone(identifier: "UTC")
+utcComps.year = 2026
+utcComps.month = 8
+utcComps.day = 14
+utcComps.hour = 16
+utcComps.minute = 30
+let cnMidnight = Calendar(identifier: .gregorian).date(from: utcComps)!
+check(MonthUsage.dayFormatter.string(from: cnMidnight) == "2026-08-15", "UTC 8/14 16:30 按北京时间归入 8/15")
+var shComps = DateComponents()
+shComps.calendar = Calendar(identifier: .gregorian)
+shComps.timeZone = TimeZone(identifier: "Asia/Shanghai")
+shComps.year = 2026
+shComps.month = 8
+shComps.day = 15
+shComps.hour = 23
+shComps.minute = 30
+let shLate = Calendar(identifier: .gregorian).date(from: shComps)!
+check(MonthUsage.dayFormatter.string(from: shLate) == "2026-08-15", "北京 8/15 23:30 仍归入 8/15")
+
 func XCTUnwrapSafe<T>(_ value: T?) throws -> T {
     guard let value else { throw NSError(domain: "unwrap", code: 1) }
     return value

--- a/Scripts/selftest/main.swift
+++ b/Scripts/selftest/main.swift
@@ -24,6 +24,7 @@ check(currencySymbol("GBP") == "£", "GBP -> £")
 check(currencySymbol("XXX") == "XXX", "未知币种原样返回")
 
 // 1.5 平台时区对齐：北京时间（UTC+8）计日，与 usage/cost、usage/amount 的 days 口径一致
+// 用例 1：跨日边界——UTC 8/14 16:30 即北京时间 8/15 00:30，必须归入 8/15（本地时区为 UTC 时会错位成 8/14）
 var utcComps = DateComponents()
 utcComps.calendar = Calendar(identifier: .gregorian)
 utcComps.timeZone = TimeZone(identifier: "UTC")

--- a/Sources/DeepSeekMeter/AppModel.swift
+++ b/Sources/DeepSeekMeter/AppModel.swift
@@ -116,7 +116,7 @@ final class AppModel: ObservableObject {
         }
         do {
             let now = Date()
-            let calendar = Calendar.current
+            let calendar = MonthUsage.platformCalendar // 与平台统计口径一致（北京时间）
             let year = calendar.component(.year, from: now)
             let month = calendar.component(.month, from: now)
             async let amountFuture = platformService.fetchUsageAmount(token: settings.platformToken, month: month, year: year)

--- a/Sources/DeepSeekMeter/AppModel.swift
+++ b/Sources/DeepSeekMeter/AppModel.swift
@@ -116,7 +116,9 @@ final class AppModel: ObservableObject {
         }
         do {
             let now = Date()
-            let calendar = MonthUsage.platformCalendar // 与平台统计口径一致（北京时间）
+            // 用平台时区（北京时间）而不是 Calendar.current：用户跨时区旅行时本地时区变化，
+            // 会导致「今日/本月」与平台统计口径错位（今日费用/请求显示 0 或错位）
+            let calendar = MonthUsage.platformCalendar
             let year = calendar.component(.year, from: now)
             let month = calendar.component(.month, from: now)
             async let amountFuture = platformService.fetchUsageAmount(token: settings.platformToken, month: month, year: year)

--- a/Sources/DeepSeekMeter/Models.swift
+++ b/Sources/DeepSeekMeter/Models.swift
@@ -133,11 +133,14 @@ struct MonthUsage: Identifiable {
         Self.dayFormatter.string(from: date)
     }
 
+    /// 平台统计口径时区：北京时间（UTC+8）。IANA 标准时区 ID 恒存在，无需回退
+    static let platformTimeZone = TimeZone(identifier: "Asia/Shanghai")!
+
     /// 平台按北京时间（UTC+8）计日与计月；App 统一用此时区判定「今日/本月」，
     /// 避免用户本地时区 ≠ UTC+8 时（跨时区旅行等）出现日期错位
     static let platformCalendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "Asia/Shanghai") ?? .current
+        calendar.timeZone = platformTimeZone
         return calendar
     }()
 
@@ -145,7 +148,7 @@ struct MonthUsage: Identifiable {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(identifier: "Asia/Shanghai") ?? .current
+        formatter.timeZone = platformTimeZone
         return formatter
     }()
 }

--- a/Sources/DeepSeekMeter/Models.swift
+++ b/Sources/DeepSeekMeter/Models.swift
@@ -133,10 +133,19 @@ struct MonthUsage: Identifiable {
         Self.dayFormatter.string(from: date)
     }
 
+    /// 平台按北京时间（UTC+8）计日与计月；App 统一用此时区判定「今日/本月」，
+    /// 避免用户本地时区 ≠ UTC+8 时（跨时区旅行等）出现日期错位
+    static let platformCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Shanghai") ?? .current
+        return calendar
+    }()
+
     static let dayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Shanghai") ?? .current
         return formatter
     }()
 }

--- a/Sources/DeepSeekMeter/Views/PopoverView.swift
+++ b/Sources/DeepSeekMeter/Views/PopoverView.swift
@@ -148,6 +148,16 @@ struct PopoverView: View {
                     statCell(title: "今日请求", value: Self.countString(today.requests))
                     statCell(title: "今日输出", value: Self.tokenString(today.response))
                 }
+                if usage.cost(on: Date()) == 0 && usage.totalCost > 0 {
+                    Text("当日费用统计可能有延迟，余额为实时扣减")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                if usage.cost(on: Date()) == 0 && usage.totalCost > 0 {
+                    Text("当日费用统计可能有延迟，余额为实时扣减")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
                 HStack(spacing: 10) {
                     statCell(title: "本月请求", value: Self.countString(usage.totalRequests))
                     statCell(title: "本月输出", value: Self.tokenString(usage.responseTokens))

--- a/Sources/DeepSeekMeter/Views/PopoverView.swift
+++ b/Sources/DeepSeekMeter/Views/PopoverView.swift
@@ -149,12 +149,7 @@ struct PopoverView: View {
                     statCell(title: "今日输出", value: Self.tokenString(today.response))
                 }
                 if usage.cost(on: Date()) == 0 && usage.totalCost > 0 {
-                    Text("当日费用统计可能有延迟，余额为实时扣减")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
-                if usage.cost(on: Date()) == 0 && usage.totalCost > 0 {
-                    Text("当日费用统计可能有延迟，余额为实时扣减")
+                    Text("当日费用统计可能延迟数小时，余额为实时扣减")
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }


### PR DESCRIPTION
## 描述

修复「今日费用显示 0」相关的两个问题（本次用户实际遇到的是平台统计延迟，但顺带加固了时区边界）：

1. **时区对齐**：App 的「今日/本月」判定原来用本地时区，平台（DeepSeek）按北京时间（UTC+8）计日/计月。用户本地时区 ≠ UTC+8 时（如跨时区旅行）会导致今日费用/本月数据错位。现在统一固定 `Asia/Shanghai`。
2. **UI 提示**：今日费用为 0 但本月有消费时，提示「当日费用统计可能有延迟，余额为实时扣减」（平台 usage/cost 当日数据非实时）。
3. **文档**：README 修正延迟说明（数分钟 → 数小时/次日）。

## 变更类型

- [x] 🐛 Bug 修复（时区边界）
- [x] 📝 文档

## 本地验证

- [x] swift build 通过
- [x] bash Scripts/run-tests.sh 全部通过（含新增 2 条时区对齐自测）

## 边界检查

- [x] 未引入任何第三方依赖
- [x] 未改动平台接口契约
- [x] 未夹带真实 Token / 凭据
- [x] 未提交构建产物
- [x] 未改变 Token 存储方式
- [x] 注释与 UI 文案保持中文
