### PR TITLE
修复 PR #4 审查问题：设置持久化一致性、DPAPI 内存、托盘图标所有权与图标文档

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,7 +76,7 @@ pwsh Scripts/publish-windows.ps1    # 生成 windows/publish/DeepSeekMeter-win-x
 
 详见 [windows/README.md](windows/README.md)。
 
-> Windows 端鲸鱼娘金钱主题图标由 AI 为本项目生成，并非 DeepSeek 官方图标或官方角色素材；DeepSeek 相关名称、商标及官方品牌资产归其权利人所有（详见 [windows/assets/ATTRIBUTION.md](windows/assets/ATTRIBUTION.md)）。
+> Windows 端鲸鱼娘金钱主题图标由 AI 为本项目生成，并非 DeepSeek 官方图标或官方角色素材；DeepSeek 相关名称、商标及官方品牌资产归其权利人所有（详见 [windows/assets/ATTRIBUTION.zh-CN.md](windows/assets/ATTRIBUTION.zh-CN.md)）。
 
 ## 🚀 快速开始
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -99,7 +99,7 @@ dotnet run --project tests/DeepSeekMeter.Selftest -c Release   # 运行自测
 
 ## 🖼️ 图标素材
 
-Windows 端鲸鱼娘金钱主题图标由 **AI 为本项目生成**，并非 DeepSeek 官方图标或官方角色素材。DeepSeek 相关名称、商标及官方品牌资产归其权利人所有。详见 [`assets/ATTRIBUTION.md`](assets/ATTRIBUTION.md)。
+Windows 端鲸鱼娘金钱主题图标由 **AI 为本项目生成**，并非 DeepSeek 官方图标或官方角色素材。DeepSeek 相关名称、商标及官方品牌资产归其权利人所有。详见 [`assets/ATTRIBUTION.zh-CN.md`](assets/ATTRIBUTION.zh-CN.md)。
 
 ## ❓ 常见问题
 

--- a/windows/assets/ATTRIBUTION.md
+++ b/windows/assets/ATTRIBUTION.md
@@ -1,13 +1,11 @@
-# 图标素材说明（Attribution）
+# Icon Attribution
 
-本目录下的 Windows 端应用图标为 **AI 生成素材**，用于本项目（DeepSeekMeter）的界面展示：
+The Windows application icons in this directory are **AI-generated assets** created for this project (DeepSeekMeter):
 
-- `whale-girl-main.png` — 主应用图标母版（蓝发鲸鱼娘抱金币形象）
-- `whale-girl-tray.png` — 系统托盘图标母版（简化鲸鱼娘形象）
-- `../src/DeepSeekMeter/app.ico` — 由主图生成的多尺寸 Windows 图标（16~256）
+- `whale-girl-main.png` — main application icon master (blue-haired whale-girl holding a coin)
+- `whale-girl-tray.png` — system tray icon master (simplified whale-girl)
+- `../src/DeepSeekMeter/app.ico` — multi-size Windows icon generated from the main image
 
-说明：
+These icons are AI-generated for this project. They are **not** official DeepSeek icons or official character assets. DeepSeek names, trademarks, and official brand assets belong to their respective owners. This project does not claim any official authorization or endorsement from DeepSeek for these icons.
 
-- 这些图标是**为本项目生成的 AI 图片**，并非 DeepSeek 官方提供的图标或官方角色素材。
-- DeepSeek 的名称、商标及官方品牌资产归其权利人所有；本项目不声称该图标获得 DeepSeek 官方授权或认可。
-- 生成脚本 `Scripts/make-whale-icons.py` 仅用于重新生成图标，依赖 Pillow；**应用构建和运行不依赖 Python 或 Pillow**，运行时直接使用本目录下已提交的 PNG 与 ICO。
+These PNG/ICO files are versioned source assets required by the app at build time; the app does not depend on Python, Pillow, or any external image at build or runtime.

--- a/windows/assets/ATTRIBUTION.zh-CN.md
+++ b/windows/assets/ATTRIBUTION.zh-CN.md
@@ -1,0 +1,11 @@
+# 图标素材说明
+
+本目录下的 Windows 端应用图标是**为本项目（DeepSeekMeter）生成的 AI 图片**：
+
+- `whale-girl-main.png` — 主应用图标母版（蓝发鲸鱼娘抱金币形象）
+- `whale-girl-tray.png` — 系统托盘图标母版（简化鲸鱼娘形象）
+- `../src/DeepSeekMeter/app.ico` — 由主图生成的多尺寸 Windows 图标
+
+这些图标为 AI 生成素材，**并非 DeepSeek 官方图标或官方角色素材**。DeepSeek 的名称、商标及官方品牌资产归其权利人所有；本项目不声称该图标获得 DeepSeek 官方授权或认可。
+
+上述 PNG/ICO 文件是应用构建时所需的版本化源资源；应用构建和运行不依赖 Python、Pillow 或任何外部图片。

--- a/windows/src/DeepSeekMeter.Core/Formatting.cs
+++ b/windows/src/DeepSeekMeter.Core/Formatting.cs
@@ -39,10 +39,10 @@ public static class Formatting
         return Format(n);
     }
 
-    /// <summary>Token 完整数值（千分位整数，用于悬停详情）。</summary>
+    /// <summary>Token 完整数值（千分位，用于悬停详情）。不用 long 强转以避免超大数值溢出。</summary>
     public static string TokenFullString(double n)
     {
-        return ((long)Math.Round(n)).ToString("N0", CultureInfo.InvariantCulture);
+        return n.ToString("N0", CultureInfo.InvariantCulture);
     }
 
     /// <summary>请求数展示：千分位。</summary>

--- a/windows/src/DeepSeekMeter.Core/SettingsStore.cs
+++ b/windows/src/DeepSeekMeter.Core/SettingsStore.cs
@@ -2,13 +2,14 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DeepSeekMeter.Core;
 
 /// <summary>
-/// 用户设置：平台 Token + 刷新间隔 + 开机自启。
-/// 持久化到本机 JSON 文件（默认 %APPDATA%\DeepSeekMeter\settings.json），
-/// 对齐 macOS 版 SettingsStore.swift 的 UserDefaults/plist 语义（Token 只存本机、不存钥匙串）。
+/// 用户设置：平台 Token（DPAPI 加密）+ 刷新间隔 + 开机自启。
+/// 持久化到本机 JSON 文件（默认 %APPDATA%\DeepSeekMeter\settings.json）。
+/// 凭据通过原子操作写入：先加密并落盘成功，再更新内存状态，失败不假装成功。
 /// </summary>
 public sealed class SettingsStore : INotifyPropertyChanged
 {
@@ -22,6 +23,9 @@ public sealed class SettingsStore : INotifyPropertyChanged
     private string _platformUserName = "";
     private double _refreshInterval = 60;
     private bool _launchAtLogin;
+
+    /// <summary>构造完成后可读取的启动警告（迁移/解密失败），由应用启动后展示一次，不含 Token。</summary>
+    public string? StartupWarning { get; private set; }
 
     public SettingsStore(string? settingsFilePath = null)
     {
@@ -37,31 +41,13 @@ public sealed class SettingsStore : INotifyPropertyChanged
         return Path.Combine(dir, "settings.json");
     }
 
-    // MARK: - 属性（变更即保存，对齐 didSet 行为）
+    // MARK: - 属性
 
-    public string PlatformToken
-    {
-        get => _platformToken;
-        set
-        {
-            if (_platformToken == value) return;
-            _platformToken = value;
-            OnPropertyChanged();
-            Save();
-        }
-    }
+    /// <summary>平台 Token（内存中的明文，仅用于网络请求；落盘时加密）。</summary>
+    public string PlatformToken => _platformToken;
 
-    public string PlatformUserName
-    {
-        get => _platformUserName;
-        set
-        {
-            if (_platformUserName == value) return;
-            _platformUserName = value;
-            OnPropertyChanged();
-            Save();
-        }
-    }
+    /// <summary>平台用户名（邮箱）。</summary>
+    public string PlatformUserName => _platformUserName;
 
     public double RefreshInterval
     {
@@ -69,9 +55,17 @@ public sealed class SettingsStore : INotifyPropertyChanged
         set
         {
             if (Math.Abs(_refreshInterval - value) < 0.001) return;
+            var previous = _refreshInterval;
             _refreshInterval = value;
-            OnPropertyChanged();
-            Save();
+            if (WriteSettings(_platformToken, _platformUserName, out var error))
+            {
+                OnPropertyChanged();
+            }
+            else
+            {
+                _refreshInterval = previous; // 保存失败回滚，不假装成功
+                SaveFailed?.Invoke(error ?? "设置保存失败");
+            }
         }
     }
 
@@ -81,36 +75,50 @@ public sealed class SettingsStore : INotifyPropertyChanged
         set
         {
             if (_launchAtLogin == value) return;
+            var previous = _launchAtLogin;
             _launchAtLogin = value;
-            OnPropertyChanged();
-            Save();
+            if (WriteSettings(_platformToken, _platformUserName, out var error))
+            {
+                OnPropertyChanged();
+            }
+            else
+            {
+                _launchAtLogin = previous;
+                SaveFailed?.Invoke(error ?? "设置保存失败");
+            }
         }
     }
 
-    public void ClearPlatformToken()
+    // MARK: - 原子凭据操作
+
+    /// <summary>原子保存平台凭据：先加密并落盘成功，再更新内存；失败不改内存并返回脱敏错误。</summary>
+    public bool TrySetPlatformCredentials(string token, string userName, out string? error)
     {
+        error = null;
+        if (!WriteSettings(token, userName, out error)) return false;
+
+        _platformToken = token;
+        _platformUserName = userName;
+        OnPropertyChanged(nameof(PlatformToken));
+        OnPropertyChanged(nameof(PlatformUserName));
+        return true;
+    }
+
+    /// <summary>原子清除平台凭据：先在设置文件移除加密字段成功，再清内存；失败保留一致登录状态。</summary>
+    public bool TryClearPlatformCredentials(out string? error)
+    {
+        error = null;
+        if (!WriteSettings(null, null, out error)) return false;
+
         _platformToken = "";
         _platformUserName = "";
         OnPropertyChanged(nameof(PlatformToken));
         OnPropertyChanged(nameof(PlatformUserName));
-        Save(); // 写空：PlatformTokenProtected 为 null，明文字段不写入
-        // 清理可能残留的临时设置文件（其中也可能含密文）
-        try
-        {
-            var tmp = SettingsFilePath + ".tmp";
-            if (File.Exists(tmp)) File.Delete(tmp);
-        }
-        catch
-        {
-            // 忽略临时文件清理失败
-        }
+        return true;
     }
 
-    /// <summary>设置保存失败时触发（参数为失败原因），供 UI 提示。</summary>
+    /// <summary>设置保存失败时触发（参数为脱敏中文提示）。</summary>
     public event Action<string>? SaveFailed;
-
-    /// <summary>最近一次保存是否成功。</summary>
-    public bool LastSaveSucceeded { get; private set; } = true;
 
     // MARK: - 持久化
 
@@ -142,12 +150,29 @@ public sealed class SettingsStore : INotifyPropertyChanged
             // Token：优先解密新版密文；否则迁移旧明文
             if (!string.IsNullOrEmpty(snap.PlatformTokenProtected))
             {
-                _platformToken = UnprotectToken(snap.PlatformTokenProtected) ?? "";
+                var token = UnprotectToken(snap.PlatformTokenProtected);
+                if (token is null)
+                {
+                    _platformToken = "";
+                    StartupWarning = "本地登录信息无法解密，请重新登录";
+                }
+                else
+                {
+                    _platformToken = token;
+                }
             }
             else if (!string.IsNullOrEmpty(snap.PlatformToken))
             {
-                _platformToken = snap.PlatformToken;
-                MigrateLegacyToken(); // 加密成功后写回密文并删除明文
+                // 旧明文迁移：加密成功落盘后才视为迁移成功；失败保留旧文件
+                if (WriteSettings(snap.PlatformToken, snap.PlatformUserName, out _))
+                {
+                    _platformToken = snap.PlatformToken;
+                }
+                else
+                {
+                    _platformToken = "";
+                    StartupWarning = "本地登录信息迁移失败，请重新登录";
+                }
             }
         }
         catch (Exception ex)
@@ -157,23 +182,51 @@ public sealed class SettingsStore : INotifyPropertyChanged
         }
     }
 
-    /// <summary>旧明文 Token 迁移：加密成功后重新保存（密文替换明文，旧文件在加密失败时不受影响）。</summary>
-    private void MigrateLegacyToken()
+    /// <summary>
+    /// 底层持久化：加密 token（若非空）后原子写入设置文件。返回是否成功及脱敏错误。
+    /// 不修改任何内存字段；.tmp 中只含密文。
+    /// </summary>
+    private bool WriteSettings(string? token, string? userName, out string? error)
     {
+        error = null;
+        string? protectedToken = null;
+        if (!string.IsNullOrEmpty(token))
+        {
+            try
+            {
+                protectedToken = Convert.ToBase64String(TokenProtector.Protect(token));
+            }
+            catch
+            {
+                error = "本地登录信息加密失败，请重试";
+                return false;
+            }
+        }
+
         try
         {
-            Save(); // Save 只写 PlatformTokenProtected，加密失败会抛异常并保留旧文件
+            var dir = Path.GetDirectoryName(SettingsFilePath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+            var snap = new Snapshot
+            {
+                PlatformTokenProtected = protectedToken,
+                PlatformUserName = userName,
+                RefreshInterval = _refreshInterval,
+                LaunchAtLogin = _launchAtLogin,
+            };
+            var json = JsonSerializer.Serialize(snap, SnapshotOptions);
+            var tmp = SettingsFilePath + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, SettingsFilePath, overwrite: true);
+            return true;
         }
-        catch
+        catch (Exception ex)
         {
-            // 加密失败：保留旧明文配置，不破坏；下次仍可重试
+            error = "设置保存失败，请检查磁盘空间或文件权限";
+            // 只记录不含 Token、不含路径敏感信息的可读错误
+            System.Diagnostics.Debug.WriteLine($"[DeepSeekMeter] 设置保存失败：{ex.Message}");
+            return false;
         }
-    }
-
-    private static string? ProtectToken(string token)
-    {
-        if (string.IsNullOrEmpty(token)) return null;
-        return Convert.ToBase64String(TokenProtector.Protect(token));
     }
 
     private static string? UnprotectToken(string base64)
@@ -189,40 +242,10 @@ public sealed class SettingsStore : INotifyPropertyChanged
         }
     }
 
-    private void Save()
-    {
-        try
-        {
-            var dir = Path.GetDirectoryName(SettingsFilePath);
-            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-            var snap = new Snapshot
-            {
-                // 不写明文 PlatformToken，只写密文 PlatformTokenProtected
-                PlatformTokenProtected = ProtectToken(_platformToken),
-                PlatformUserName = _platformUserName,
-                RefreshInterval = _refreshInterval,
-                LaunchAtLogin = _launchAtLogin,
-            };
-            var json = JsonSerializer.Serialize(snap, SnapshotOptions);
-            // 原子写入：先写临时文件再替换（.tmp 中只含密文）
-            var tmp = SettingsFilePath + ".tmp";
-            File.WriteAllText(tmp, json);
-            File.Move(tmp, SettingsFilePath, overwrite: true);
-            LastSaveSucceeded = true;
-        }
-        catch (Exception ex)
-        {
-            LastSaveSucceeded = false;
-            // 只记录不含 Token 的可读错误
-            System.Diagnostics.Debug.WriteLine($"[DeepSeekMeter] 保存设置失败：{ex.Message}");
-            SaveFailed?.Invoke("设置保存失败，请检查磁盘空间或文件权限"); // 让界面知道，不含敏感信息
-        }
-    }
-
     private static readonly JsonSerializerOptions SnapshotOptions = new()
     {
         WriteIndented = true,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
     // MARK: - INotifyPropertyChanged

--- a/windows/src/DeepSeekMeter.Core/TokenProtector.cs
+++ b/windows/src/DeepSeekMeter.Core/TokenProtector.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace DeepSeekMeter.Core;
@@ -7,6 +8,7 @@ namespace DeepSeekMeter.Core;
 /// 平台 Token 保护：使用 Windows DPAPI（CryptProtectData/CryptUnprotectData），
 /// 绑定当前 Windows 用户（CurrentUser 语义，无额外熵），零第三方依赖。
 /// 密文仅在当前用户会话内可解密；解密失败调用方按「需要重新登录」处理。
+/// 明文临时缓冲（托管与非托管）在用后清零，非托管 LocalAlloc 在所有路径统一 LocalFree。
 /// </summary>
 public static class TokenProtector
 {
@@ -25,23 +27,51 @@ public static class TokenProtector
         if (string.IsNullOrEmpty(plain)) return [];
 
         var plainBytes = Encoding.UTF8.GetBytes(plain);
-        var inBlob = new DataBlob { cbData = plainBytes.Length, pbData = Marshal.AllocHGlobal(plainBytes.Length) };
+        try
+        {
+            return ProtectCore(plainBytes);
+        }
+        finally
+        {
+            // 清理托管明文副本
+            CryptographicOperations.ZeroMemory(plainBytes);
+        }
+    }
+
+    private static byte[] ProtectCore(byte[] plainBytes)
+    {
+        var inBlob = default(DataBlob);
+        var outBlob = default(DataBlob);
+        inBlob.pbData = Marshal.AllocHGlobal(plainBytes.Length);
+        inBlob.cbData = plainBytes.Length;
         try
         {
             Marshal.Copy(plainBytes, 0, inBlob.pbData, plainBytes.Length);
             var entropy = default(DataBlob); // 无额外熵，仅绑定当前用户
-            var outBlob = default(DataBlob);
             if (!CryptProtectData(ref inBlob, null, ref entropy, IntPtr.Zero, IntPtr.Zero, CryptprotectUiForbidden, ref outBlob))
-                throw new InvalidOperationException("令牌加密失败");
-
+            {
+                var winErr = Marshal.GetLastWin32Error();
+                throw new InvalidOperationException($"令牌加密失败（错误码 0x{winErr:X8}）");
+            }
             var result = new byte[outBlob.cbData];
             Marshal.Copy(outBlob.pbData, result, 0, outBlob.cbData);
-            LocalFree(outBlob.pbData);
             return result;
         }
         finally
         {
-            Marshal.FreeHGlobal(inBlob.pbData);
+            // 释放 DPAPI 输出（LocalAlloc）
+            if (outBlob.pbData != IntPtr.Zero)
+            {
+                LocalFree(outBlob.pbData);
+                outBlob.pbData = IntPtr.Zero;
+            }
+            // 释放前清零非托管输入缓冲（含明文）
+            if (inBlob.pbData != IntPtr.Zero)
+            {
+                ZeroNative(inBlob.pbData, plainBytes.Length);
+                Marshal.FreeHGlobal(inBlob.pbData);
+                inBlob.pbData = IntPtr.Zero;
+            }
         }
     }
 
@@ -50,19 +80,27 @@ public static class TokenProtector
     {
         if (cipher is null || cipher.Length == 0) return null;
 
-        var inBlob = new DataBlob { cbData = cipher.Length, pbData = Marshal.AllocHGlobal(cipher.Length) };
+        var inBlob = default(DataBlob);
+        var outBlob = default(DataBlob);
+        inBlob.pbData = Marshal.AllocHGlobal(cipher.Length);
+        inBlob.cbData = cipher.Length;
         try
         {
             Marshal.Copy(cipher, 0, inBlob.pbData, cipher.Length);
             var entropy = default(DataBlob);
-            var outBlob = default(DataBlob);
             if (!CryptUnprotectData(ref inBlob, null, ref entropy, IntPtr.Zero, IntPtr.Zero, CryptprotectUiForbidden, ref outBlob))
                 return null;
 
-            var result = new byte[outBlob.cbData];
-            Marshal.Copy(outBlob.pbData, result, 0, outBlob.cbData);
-            LocalFree(outBlob.pbData);
-            return Encoding.UTF8.GetString(result);
+            var plainBytes = new byte[outBlob.cbData];
+            Marshal.Copy(outBlob.pbData, plainBytes, 0, outBlob.cbData);
+            try
+            {
+                return Encoding.UTF8.GetString(plainBytes);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(plainBytes);
+            }
         }
         catch
         {
@@ -70,7 +108,33 @@ public static class TokenProtector
         }
         finally
         {
-            Marshal.FreeHGlobal(inBlob.pbData);
+            if (outBlob.pbData != IntPtr.Zero)
+            {
+                LocalFree(outBlob.pbData);
+                outBlob.pbData = IntPtr.Zero;
+            }
+            if (inBlob.pbData != IntPtr.Zero)
+            {
+                // 密文不敏感，但保持一致清理
+                Marshal.FreeHGlobal(inBlob.pbData);
+                inBlob.pbData = IntPtr.Zero;
+            }
+        }
+    }
+
+    private static readonly byte[] ZeroBuffer = new byte[1024];
+
+    /// <summary>清零非托管内存（用于含明文的输入缓冲）。</summary>
+    private static void ZeroNative(IntPtr ptr, int length)
+    {
+        int remaining = length;
+        int offset = 0;
+        while (remaining > 0)
+        {
+            int chunk = Math.Min(remaining, ZeroBuffer.Length);
+            Marshal.Copy(ZeroBuffer, 0, ptr + offset, chunk);
+            offset += chunk;
+            remaining -= chunk;
         }
     }
 

--- a/windows/src/DeepSeekMeter/App.xaml.cs
+++ b/windows/src/DeepSeekMeter/App.xaml.cs
@@ -53,6 +53,24 @@ public partial class App : System.Windows.Application
             await Task.Delay(500);
             _tray?.ShowPopover();
         });
+
+        // 展示一次迁移/解密警告（构造期间产生，此时 UI 已可订阅）
+        ShowStartupWarning();
+    }
+
+    /// <summary>展示一次迁移/解密警告（不含 Token）。</summary>
+    private void ShowStartupWarning()
+    {
+        if (_settings is null || string.IsNullOrEmpty(_settings.StartupWarning)) return;
+        var warning = _settings.StartupWarning;
+        try
+        {
+            MessageBox.Show(warning, "DeepSeek Meter", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch
+        {
+            // 无桌面会话时忽略提示
+        }
     }
 
     /// <summary>启动时核对设置与注册表真实状态，保证界面显示的是真实自启状态。</summary>

--- a/windows/src/DeepSeekMeter/MainViewModel.cs
+++ b/windows/src/DeepSeekMeter/MainViewModel.cs
@@ -295,8 +295,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
         try
         {
             var user = await _service.FetchCurrentUserAsync(trimmed);
-            Settings.PlatformToken = trimmed;
-            Settings.PlatformUserName = user.Email;
+            // 先校验 Token，再原子落盘（DPAPI 加密 + 写文件）；失败不触发登录成功
+            if (!Settings.TrySetPlatformCredentials(trimmed, user.Email, out var setError))
+            {
+                UsageError = setError;
+                return false;
+            }
             Currency = user.Currency;
             UsageError = null;
             PlatformTokenExpired = false;
@@ -316,9 +320,14 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     public void ClearPlatformToken()
     {
-        // 同时清除应用 Token 与 WebView2 网页登录数据（Cookie/localStorage），允许真正切换账号
+        // 先清除设置文件中的加密字段（成功才清内存，失败保留一致登录状态）
+        if (!Settings.TryClearPlatformCredentials(out var clearError))
+        {
+            LastError = "本地登录信息清除失败";
+            return;
+        }
+        // 设置文件清除成功后，再清理 WebView2 网页登录数据
         var webDataCleared = LoginWindow.ClearWebViewData();
-        Settings.ClearPlatformToken();
         MonthUsage = null;
         UsageError = null;
         LastBalance = null;
@@ -326,7 +335,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         Currency = "CNY";
         LastError = webDataCleared
             ? null
-            : "已退出登录；网页登录数据清理失败，如需切换账号请重启应用";
+            : "应用 Token 已清除，但网页登录数据清理失败";
     }
 
     // MARK: - INotifyPropertyChanged

--- a/windows/src/DeepSeekMeter/SparklineControl.cs
+++ b/windows/src/DeepSeekMeter/SparklineControl.cs
@@ -19,7 +19,8 @@ public sealed class SparklineControl : System.Windows.FrameworkElement
             nameof(Entries),
             typeof(IReadOnlyList<Entry>),
             typeof(SparklineControl),
-            new FrameworkPropertyMetadata(Array.Empty<Entry>(), FrameworkPropertyMetadataOptions.AffectsRender));
+            new FrameworkPropertyMetadata(Array.Empty<Entry>(),
+                FrameworkPropertyMetadataOptions.AffectsRender, OnHoverAffectingPropertyChanged));
 
     public IReadOnlyList<Entry> Entries
     {
@@ -33,12 +34,22 @@ public sealed class SparklineControl : System.Windows.FrameworkElement
             nameof(MetricName),
             typeof(string),
             typeof(SparklineControl),
-            new PropertyMetadata("Token"));
+            new PropertyMetadata("Token", OnHoverAffectingPropertyChanged));
 
     public string MetricName
     {
         get => (string)GetValue(MetricNameProperty);
         set => SetValue(MetricNameProperty, value);
+    }
+
+    private int _lastHoverIndex = -1;
+
+    /// <summary>指标或数据变化时重置悬停缓存，保证 ToolTip 立即反映最新指标/数据。</summary>
+    private static void OnHoverAffectingPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var control = (SparklineControl)d;
+        control._lastHoverIndex = -1;
+        control.ToolTip = null;
     }
 
     protected override void OnRender(DrawingContext dc)
@@ -108,16 +119,19 @@ public sealed class SparklineControl : System.Windows.FrameworkElement
         var entries = Entries;
         if (entries is null || entries.Count == 0 || ActualWidth <= 0)
         {
-            ToolTip = null;
+            ClearHover();
             return;
         }
         double slot = ActualWidth / entries.Count;
         int index = (int)(e.GetPosition(this).X / slot);
         if (index < 0 || index >= entries.Count)
         {
-            ToolTip = null;
+            ClearHover();
             return;
         }
+        if (index == _lastHoverIndex) return; // 槽位未变，不重复更新 ToolTip
+
+        _lastHoverIndex = index;
         var entry = entries[index];
         ToolTip = $"{entry.Date.Month}月{entry.Date.Day}日\n{MetricName}\n{Formatting.TokenFullString(entry.Value)} Token";
     }
@@ -125,6 +139,12 @@ public sealed class SparklineControl : System.Windows.FrameworkElement
     protected override void OnMouseLeave(MouseEventArgs e)
     {
         base.OnMouseLeave(e);
+        ClearHover();
+    }
+
+    private void ClearHover()
+    {
+        _lastHoverIndex = -1;
         ToolTip = null;
     }
 }

--- a/windows/src/DeepSeekMeter/TrayIconController.cs
+++ b/windows/src/DeepSeekMeter/TrayIconController.cs
@@ -14,10 +14,9 @@ public sealed class TrayIconController : IDisposable
     private readonly MainViewModel _model;
     private readonly System.Windows.Forms.NotifyIcon _notifyIcon;
     private readonly System.Windows.Forms.ContextMenuStrip _menu;
-    private Icon? _icon;
-    private IntPtr _iconHandle;
+    private Icon? _currentIcon;
     private readonly Dictionary<int, Icon> _statusIconCache = new();
-    private readonly List<IntPtr> _ownedIconHandles = new();
+    private Bitmap? _trayBaseBitmap; // 实例级母版，Dispose 时释放
     private PopoverWindow? _popover;
     private bool _disposed;
 
@@ -138,7 +137,7 @@ public sealed class TrayIconController : IDisposable
         return "DeepSeek Meter · 未登录";
     }
 
-    /// <summary>按状态颜色缓存托盘图标（鲸鱼娘 + 右下角状态点），避免每次刷新重复创建并泄漏句柄。</summary>
+    /// <summary>按状态颜色缓存托盘图标（鲸鱼娘 + 右下角状态点），避免每次刷新重复创建。</summary>
     private Icon GetStatusIcon(Color color)
     {
         int key = color.ToArgb();
@@ -146,25 +145,25 @@ public sealed class TrayIconController : IDisposable
 
         var icon = BuildStatusIcon(color);
         _statusIconCache[key] = icon;
-        _ownedIconHandles.Add(icon.Handle);
         return icon;
     }
 
-    /// <summary>加载简化鲸鱼娘母版（嵌入资源，静态缓存）。</summary>
-    private static Bitmap? _baseBitmap;
-    private static Bitmap LoadBaseBitmap()
+    /// <summary>加载简化鲸鱼娘母版（嵌入资源，实例级缓存）。</summary>
+    private Bitmap LoadBaseBitmap()
     {
-        if (_baseBitmap is not null) return _baseBitmap;
+        if (_trayBaseBitmap is not null) return _trayBaseBitmap;
         using var stream = typeof(TrayIconController).Assembly
             .GetManifestResourceStream("DeepSeekMeter.Assets.whale-girl-tray.png");
-        _baseBitmap = stream is null ? new Bitmap(32, 32) : new Bitmap(stream);
-        return _baseBitmap;
+        _trayBaseBitmap = stream is null ? new Bitmap(32, 32) : new Bitmap(stream);
+        return _trayBaseBitmap;
     }
 
-    /// <summary>绘制鲸鱼娘托盘图标：高质量缩放母版，右下角叠加白描边状态点（不挡眼睛/发饰/金币）。</summary>
-    private static Icon BuildStatusIcon(Color statusColor)
+    /// <summary>
+    /// 绘制鲸鱼娘托盘图标：高质量缩放母版，右下角叠加白描边状态点。
+    /// 句柄所有权：GetHicon 得到原始句柄 → FromHandle 临时包装 → Clone 出 .NET 独立拥有的 Icon → finally DestroyIcon 原始句柄。
+    /// </summary>
+    private Icon BuildStatusIcon(Color statusColor)
     {
-        // 注意：baseBmp 是静态缓存（_baseBitmap），不能在这里 Dispose，否则下次渲染会用到已释放的 Bitmap
         var baseBmp = LoadBaseBitmap();
         using var bmp = new Bitmap(32, 32);
         using (var g = Graphics.FromImage(bmp))
@@ -183,15 +182,23 @@ public sealed class TrayIconController : IDisposable
             using var brush = new SolidBrush(statusColor);
             g.FillEllipse(brush, x, y, dot, dot);
         }
-        return Icon.FromHandle(bmp.GetHicon());
+
+        IntPtr hIcon = bmp.GetHicon();
+        try
+        {
+            using var temp = Icon.FromHandle(hIcon);
+            return (Icon)temp.Clone(); // 克隆出由 .NET 独立拥有的 Icon，可安全缓存并 Dispose
+        }
+        finally
+        {
+            DestroyIcon(hIcon); // 释放原始句柄，避免泄漏
+        }
     }
 
     private void SetIcon(Icon icon)
     {
-        if (ReferenceEquals(_icon, icon)) return;
-        // 图标句柄由 _ownedIconHandles 统一管理，切换时不释放（缓存复用）
-        _icon = icon;
-        _iconHandle = icon.Handle;
+        if (ReferenceEquals(_currentIcon, icon)) return;
+        _currentIcon = icon;
         _notifyIcon.Icon = icon;
     }
 
@@ -205,20 +212,15 @@ public sealed class TrayIconController : IDisposable
         _popover?.Close();
         _popover = null;
 
-        // 统一释放所有缓存托盘图标句柄与对象（含当前图标）
-        _icon = null;
-        _iconHandle = IntPtr.Zero;
-        foreach (var handle in _ownedIconHandles)
-        {
-            if (handle != IntPtr.Zero) DestroyIcon(handle);
-        }
-        _ownedIconHandles.Clear();
+        // 先隐藏并清空托盘图标，再释放缓存的克隆 Icon 与母版 Bitmap
+        _notifyIcon.Visible = false;
+        _notifyIcon.Icon = null;
+        _currentIcon = null;
         foreach (var icon in _statusIconCache.Values) icon.Dispose();
         _statusIconCache.Clear();
-        _baseBitmap?.Dispose();
-        _baseBitmap = null;
+        _trayBaseBitmap?.Dispose();
+        _trayBaseBitmap = null;
 
-        _notifyIcon.Visible = false;
         _notifyIcon.Dispose();
         _menu.Dispose();
     }

--- a/windows/tests/DeepSeekMeter.Selftest/Program.cs
+++ b/windows/tests/DeepSeekMeter.Selftest/Program.cs
@@ -195,8 +195,7 @@ var tmpFile = Path.Combine(Path.GetTempPath(), $"dsm-settings-{Guid.NewGuid():N}
 try
 {
     var store = new SettingsStore(tmpFile);
-    store.PlatformToken = "test-token";
-    store.PlatformUserName = "test@example.com";
+    Check(store.TrySetPlatformCredentials("test-token", "test@example.com", out _), "原子设置凭据成功");
     store.RefreshInterval = 300;
     store.LaunchAtLogin = true;
 
@@ -206,7 +205,7 @@ try
     Check(Math.Abs(reloaded.RefreshInterval - 300) < 0.001, "设置往返：刷新间隔");
     Check(reloaded.LaunchAtLogin, "设置往返：开机自启");
 
-    reloaded.ClearPlatformToken();
+    Check(reloaded.TryClearPlatformCredentials(out _), "原子清除凭据成功");
     Check(reloaded.PlatformToken == "" && reloaded.PlatformUserName == "", "清除 Token");
 }
 finally
@@ -271,9 +270,15 @@ try
     var store3 = new SettingsStore(dirAsFile);
     var failed = false;
     store3.SaveFailed += _ => failed = true;
-    store3.RefreshInterval = 300; // 触发保存
+    store3.RefreshInterval = 300; // 触发保存失败
     Check(failed, "设置保存失败触发 SaveFailed 事件");
-    Check(!store3.LastSaveSucceeded, "设置保存失败后 LastSaveSucceeded 为 false");
+    Check(Math.Abs(store3.RefreshInterval - 60) < 0.001, "保存失败后刷新间隔回滚");
+
+    // 凭据落盘失败不会报告成功
+    var setOk = store3.TrySetPlatformCredentials("secret", "u@x.com", out var setErr);
+    Check(!setOk, "凭据落盘失败返回 false");
+    Check(!string.IsNullOrEmpty(setErr), "凭据落盘失败返回脱敏错误");
+    Check(store3.PlatformToken == "", "凭据落盘失败不更新内存 Token");
 }
 finally
 {
@@ -326,7 +331,7 @@ var encFile = Path.Combine(Path.GetTempPath(), $"dsm-enc-{Guid.NewGuid():N}.json
 try
 {
     var store = new SettingsStore(encFile);
-    store.PlatformToken = encToken;
+    store.TrySetPlatformCredentials(encToken, "", out _);
     var json = File.ReadAllText(encFile);
     Check(!json.Contains(encToken), "设置文件不含明文 Token");
     Check(json.Contains("PlatformTokenProtected"), "设置文件含加密字段 PlatformTokenProtected");
@@ -345,13 +350,14 @@ try
     }
     finally { if (File.Exists(legacyFile)) File.Delete(legacyFile); }
 
-    // 损坏密文安全回退（不崩溃，Token 视为空 = 需要重新登录）
+    // 损坏密文安全回退（不崩溃，Token 视为空 = 需要重新登录，且给出警告）
     var corruptFile = Path.Combine(Path.GetTempPath(), $"dsm-corrupt-{Guid.NewGuid():N}.json");
     try
     {
         File.WriteAllText(corruptFile, """{"PlatformTokenProtected":"!!not-base64!!"}""");
         var corrupt = new SettingsStore(corruptFile);
         Check(corrupt.PlatformToken == "", "损坏密文回退为空 Token");
+        Check(!string.IsNullOrEmpty(corrupt.StartupWarning), "损坏密文给出需要重新登录警告");
     }
     finally { if (File.Exists(corruptFile)) File.Delete(corruptFile); }
 
@@ -360,8 +366,8 @@ try
     try
     {
         var clear = new SettingsStore(clearFile);
-        clear.PlatformToken = "token-to-clear-456";
-        clear.ClearPlatformToken();
+        clear.TrySetPlatformCredentials("token-to-clear-456", "", out _);
+        Check(clear.TryClearPlatformCredentials(out _), "退出登录清除凭据成功");
         var clearedJson = File.ReadAllText(clearFile);
         Check(!clearedJson.Contains("token-to-clear-456"), "退出登录后文件不含 Token");
         Check(!clearedJson.Contains("PlatformTokenProtected"), "退出登录后无加密字段");
@@ -455,6 +461,30 @@ catch (Exception ex)
 {
     Check(false, $"by_api_key 解码/聚合抛错：{ex.Message}");
 }
+
+// 17. 明文迁移失败状态（.tmp 被目录占用导致写失败，保留旧明文并给出警告）
+var migrateFailFile = Path.Combine(Path.GetTempPath(), $"dsm-migfail-{Guid.NewGuid():N}.json");
+var migrateFailTmp = migrateFailFile + ".tmp";
+try
+{
+    File.WriteAllText(migrateFailFile, """{"PlatformToken":"migrate-fail-token","PlatformUserName":"u@x.com"}""");
+    Directory.CreateDirectory(migrateFailTmp); // 让 .tmp 路径成为目录，写文件失败
+    var s = new SettingsStore(migrateFailFile);
+    Check(s.PlatformToken == "", "迁移失败后 Token 为空");
+    Check(!string.IsNullOrEmpty(s.StartupWarning), "迁移失败给出警告");
+    Check(File.ReadAllText(migrateFailFile).Contains("migrate-fail-token"), "迁移失败保留旧明文文件");
+}
+finally
+{
+    if (Directory.Exists(migrateFailTmp)) Directory.Delete(migrateFailTmp, true);
+    if (File.Exists(migrateFailFile)) File.Delete(migrateFailFile);
+}
+
+// 18. 超大 Token 数值格式化（不用 long 强转，避免溢出）
+var huge = Formatting.TokenFullString(1e20);
+Check(huge.Length > 0, "超大数值格式化非空");
+Check(!huge.Contains("E+") && !huge.Contains("e+"), "超大数值不用科学计数法");
+Check(Formatting.TokenFullString(84217000) == "84,217,000", "正常千分位不变");
 
 if (failures > 0)
 {


### PR DESCRIPTION
## 描述

针对已合并的 PR #4 的审查意见，补充以下修复：

**设置持久化一致性**
- SettingsStore 底层保存返回成功/失败及脱敏错误，新增 TrySetPlatformCredentials / TryClearPlatformCredentials 原子操作
- 登录先校验再加密落盘，失败不报告成功；退出登录先清设置文件成功才清内存/WebView2
- 旧明文迁移增加 StartupWarning，损坏密文提示需要重新登录，启动后展示一次

**DPAPI 内存与错误处理**
- LocalAlloc 输出全路径 LocalFree，非托管输入缓冲释放前清零，托管明文 ZeroMemory
- Marshal.GetLastWin32Error 取错误码，用户仅见脱敏中文

**托盘图标所有权**
- 删除双重所有权，改为 GetHicon → FromHandle → Clone → DestroyIcon，缓存克隆 Icon
- 退出先清 NotifyIcon 再释放，母版 Bitmap 改实例级

**图标文档**
- 删除 Pillow 图标生成脚本，ATTRIBUTION 双语（英文 + 中文）

**低风险**
- TokenFullString 改用 double 格式避免溢出；SparklineControl 缓存悬停索引

## 变更类型

- [x] 🐛 Bug 修复 / 安全加固
- [ ] ✨ 新功能
- [ ] ♻️ 重构
- [x] 📝 文档
- [ ] ⚙️ CI / 构建脚本

## 本地验证

- [x] Windows Release 构建（0 警告 0 错误）
- [x] 全部自测通过（凭据落盘失败、迁移失败、损坏密文、超大数值等）
- [x] NuGet 无已知漏洞（含传递依赖）
- [x] git diff --check 通过

## 边界检查

- [x] 未引入第三方依赖（DPAPI 用 P/Invoke）
- [x] 未夹带真实 Token / 凭据
- [x] 未提交构建产物
- [x] 中文注释与 UI 文案，文档双语